### PR TITLE
fixing bug where substring was looking for -1 but was using .index

### DIFF
--- a/src/utils/load_fusion_3x_config.py
+++ b/src/utils/load_fusion_3x_config.py
@@ -68,7 +68,7 @@ def load_config_from_file(path, service="ui"):
 
 
 def parse_solr_namespace(solr_zk_connect):
-    index = solr_zk_connect.index("/")
+    index = solr_zk_connect.find("/")
     if index != -1:
         return solr_zk_connect[index:len(solr_zk_connect)]
     else:


### PR DESCRIPTION
fixing bug where substring was looking for -1 but was using .index instead of .find; .index throws a value error, not returning a -1 when the substring does not exist.