### PR TITLE
MAIN: Allow for secondary ZK cluster to upgrade from instead of forcing same-runtime

### DIFF
--- a/src/migrator/api_pojo_migrator.py
+++ b/src/migrator/api_pojo_migrator.py
@@ -2,14 +2,20 @@ import logging
 import json
 import sys
 
-def update_searchcluster_pojo(config, zk):
+def update_searchcluster_pojo(config, zk, old_zk):
     solr_zk_connect_string = config["solr.zk.connect"]
     searchcluster_znode_path = "{}/search-clusters/default".format(config["api.namespace"])
-    if not zk.exists(searchcluster_znode_path):
+    
+    # if the POJO does not exist on either server, exit... Otherwise, grab it from the appropriate server
+    if old_zk and old_zk.exists(searchcluster_znode_path):
+        value, zstat = old_zk.get(searchcluster_znode_path)    
+    elif zk.exists(searchcluster_znode_path):
+        value, zstat = zk.get(searchcluster_znode_path)
+    else:
         sys.exit("Search cluster POJO does not exist at zpath '{}'".format(searchcluster_znode_path))
 
     # Read the payload from Zookeeper
-    value, zstat = zk.get(searchcluster_znode_path)
+    
     deser_payload = json.loads(value)
     deser_payload["connectString"] = solr_zk_connect_string
 

--- a/src/migrator/api_pojo_migrator.py
+++ b/src/migrator/api_pojo_migrator.py
@@ -12,7 +12,8 @@ def update_searchcluster_pojo(config, zk, old_zk):
     elif zk.exists(searchcluster_znode_path):
         value, zstat = zk.get(searchcluster_znode_path)
     else:
-        sys.exit("Search cluster POJO does not exist at zpath '{}'".format(searchcluster_znode_path))
+        logging.critical("Search cluster POJO does not exist at zpath '{}'".format(searchcluster_znode_path))
+        sys.exit(1)
 
     # Read the payload from Zookeeper
     

--- a/src/migrator/api_pojo_migrator.py
+++ b/src/migrator/api_pojo_migrator.py
@@ -1,6 +1,7 @@
 import logging
 import json
 import sys
+logger = logging.getLogger(__name__)
 
 def update_searchcluster_pojo(config, zk, old_zk):
     solr_zk_connect_string = config["solr.zk.connect"]
@@ -12,7 +13,7 @@ def update_searchcluster_pojo(config, zk, old_zk):
     elif zk.exists(searchcluster_znode_path):
         value, zstat = zk.get(searchcluster_znode_path)
     else:
-        logging.critical("Search cluster POJO does not exist at zpath '{}'".format(searchcluster_znode_path))
+        logger.critical("Search cluster POJO does not exist at zpath '{}'".format(searchcluster_znode_path))
         sys.exit(1)
 
     # Read the payload from Zookeeper
@@ -20,6 +21,6 @@ def update_searchcluster_pojo(config, zk, old_zk):
     deser_payload = json.loads(value)
     deser_payload["connectString"] = solr_zk_connect_string
 
-    logging.info("Updating search-cluster payload at path '{}'".format(searchcluster_znode_path))
+    logger.info("Updating search-cluster payload at path '{}'".format(searchcluster_znode_path))
     # Write the updated payload to Zookeeper
     zk.set(searchcluster_znode_path, value=json.dumps(deser_payload))

--- a/src/migrator/base_migrator.py
+++ b/src/migrator/base_migrator.py
@@ -3,7 +3,7 @@ from src.utils.constants import *
 import logging
 
 class BaseMigrator:
-
+  logger = logging.getLogger(__name__)
   def delete_properties(self, data_source, properties):
     for property in properties:
       try:
@@ -11,6 +11,6 @@ class BaseMigrator:
           if property in data_source[PROPERTIES]:
             del data_source[PROPERTIES][property]
       except:
-        logging.warn("Could not delete property: %s", property)
+        logger.warn("Could not delete property: %s", property)
         continue
     return data_source

--- a/src/migrator/base_migrator.py
+++ b/src/migrator/base_migrator.py
@@ -1,9 +1,9 @@
 from src.utils.constants import *
 
 import logging
+logger = logging.getLogger(__name__)
 
 class BaseMigrator:
-  logger = logging.getLogger(__name__)
   def delete_properties(self, data_source, properties):
     for property in properties:
       try:

--- a/src/migrator/config_migrator.py
+++ b/src/migrator/config_migrator.py
@@ -7,9 +7,9 @@ from collections import OrderedDict
 from utils.jproperties import Properties
 from utils.variables_helper import VariablesHelper
 
+logger = logging.getLogger(__name__)
 
 class ConfigMigrator():
-    logger = logging.getLogger(__name__)
     # These are the defaults as of 2.4.3. Do we need different defaults for different versions?
     default_properties = {"API_JAVA_OPTIONS": "-Xmx1g -XX:MaxPermSize=256m -Dapple.awt.UIElement=true",
                           "API_PORT": "8765",

--- a/src/migrator/config_migrator.py
+++ b/src/migrator/config_migrator.py
@@ -9,6 +9,7 @@ from utils.variables_helper import VariablesHelper
 
 
 class ConfigMigrator():
+    logger = logging.getLogger(__name__)
     # These are the defaults as of 2.4.3. Do we need different defaults for different versions?
     default_properties = {"API_JAVA_OPTIONS": "-Xmx1g -XX:MaxPermSize=256m -Dapple.awt.UIElement=true",
                           "API_PORT": "8765",
@@ -104,7 +105,7 @@ class ConfigMigrator():
                             new_config[hostname_key] = match.group(1)
                             value = value.replace(match.group(), "")  # strip out the hostname arg
                     
-                    logging.debug("{} ({}): {}".format(old_key, new_key, value))
+                    logger.debug("{} ({}): {}".format(old_key, new_key, value))
                     
                     # For each thing we've found, compare against the default values from the old config. If they're
                     # the same as default, don't bother to set them. Note that that means we're potentially changing
@@ -114,13 +115,13 @@ class ConfigMigrator():
                     if old_key in self.default_properties and value != self.default_properties[old_key]:
                         new_config[new_key] = value
         
-        logging.debug("new config: {}".format(new_config))
+        logger.debug("new config: {}".format(new_config))
         return new_config
     
     def convert(self):
         new_config = self.generate_new_config()
         if len(new_config) == 0:
-            logging.info("No properties to update from config.sh to fusion.properties")
+            logger.info("No properties to update from config.sh to fusion.properties")
             return
         
         config_file_path = os.path.join(self.new_home, "conf", "fusion.properties")
@@ -139,7 +140,7 @@ class ConfigMigrator():
         # write it
         with open(config_file_path, "w") as f:
             f.write(str(props))
-            logging.info("Updated fusion.properties with the properties: {}".format(new_config))
+            logger.info("Updated fusion.properties with the properties: {}".format(new_config))
     
     def clean_java_options(self, java_options):
         return java_options.lstrip('( ').rstrip(') ')

--- a/src/migrator/connectors_migrator.py
+++ b/src/migrator/connectors_migrator.py
@@ -104,7 +104,7 @@ class ConnectorsMigrator3x:
         # No reason to check existance of connectors_znode here since it isn't used past generating datasources_znode
         # set the read_zk to old_zk if old_zk exists and the node exists there
         if self.old_zk_client and self.old_zk_client.exists(datasources_znode):
-            read_zk = old_zk_client
+            read_zk = self.old_zk_client
         elif not self.read_zk.exists(datasources_znode):
             logger.info("Connectors znode path {} does not exist. No migrations to perform".format(connectors_znode))
             return

--- a/src/migrator/connectors_migrator.py
+++ b/src/migrator/connectors_migrator.py
@@ -103,7 +103,7 @@ class ConnectorsMigrator3x:
 
         # No reason to check existance of connectors_znode here since it isn't used past generating datasources_znode
         # set the read_zk to old_zk if old_zk exists and the node exists there
-        if self.old_zk and self.old_zk_client.exists(datasources_znode):
+        if self.old_zk_client and self.old_zk_client.exists(datasources_znode):
             read_zk = old_zk_client
         elif not self.read_zk.exists(datasources_znode):
             logger.info("Connectors znode path {} does not exist. No migrations to perform".format(connectors_znode))

--- a/src/migrator/connectors_migrator.py
+++ b/src/migrator/connectors_migrator.py
@@ -13,8 +13,9 @@ import re
 import sys
 import json
 
+logger = logging.getLogger(__name__)
+
 class ConnectorsMigrator:
-  logger = logging.getLogger(__name__)
   def __init__(self):
     self.class_loader = ClassLoader()
     self.zk_fusion_host = VariablesHelper.get_fusion_zookeeper_host()
@@ -84,7 +85,6 @@ class ConnectorsMigrator:
             continue
 
 class ConnectorsMigrator3x:
-    logger = logging.getLogger(__name__)
     def __init__(self, config, zk, old_zk):
         self.class_loader = ClassLoader()
         self.zk_fusion_host = config["fusion.zk.connect"]

--- a/src/migrator/nlp_pipelines_migrator.py
+++ b/src/migrator/nlp_pipelines_migrator.py
@@ -8,7 +8,7 @@ from src.utils.zookeeper_client import ZookeeperClient
 from src.utils.variables_helper import VariablesHelper
 
 import logging
-
+logger = logging.getLogger(__name__)
 
 OPENNLP_TYPE = "nlp-extractor"
 LOOKUP_TYPE = "lookup-extractor"
@@ -17,7 +17,6 @@ LOOKUP_TYPE = "lookup-extractor"
     Should be used to upgrade from 2.1.x to 2.4.x
 """
 class PipelinesNLPMigrator:
-
     def __init__(self):
         self.class_loader = ClassLoader()
         self.zk_fusion_host = VariablesHelper.get_fusion_zookeeper_host()
@@ -39,7 +38,7 @@ class PipelinesNLPMigrator:
             pipeline = self.zookeeper_client.get_as_json(pipeline_node)
             is_pipeline_updated = fix_pipeline_extractor_stages(pipeline)
             if is_pipeline_updated:
-                logging.info("Updating pipeline '{}'".format(pipeline.get("id")))
+                logger.info("Updating pipeline '{}'".format(pipeline.get("id")))
                 self.zookeeper_client.set_as_json(pipeline_node, pipeline)
 
 def fix_pipeline_extractor_stages(pipeline):
@@ -91,7 +90,7 @@ class PipelinesNLPMigrator3x:
         if self.old_zk and self.old_zk.exists(zk_pipelines_node):
             read_zk = old_zk
         elif not self.read_zk.exists(zk_pipelines_node):
-            logging.info("NLP znode path {} does not exist. No migrations to perform".format(zk_pipeline_node))
+            logger.info("NLP znode path {} does not exist. No migrations to perform".format(zk_pipeline_node))
             return
 
         children = self.read_zk.get_children(zk_pipelines_node)
@@ -102,5 +101,5 @@ class PipelinesNLPMigrator3x:
 
             is_pipeline_updated = fix_pipeline_extractor_stages(pipeline)
             if is_pipeline_updated:
-                logging.info("Updating pipeline '{}'".format(pipeline.get("id")))
+                logger.info("Updating pipeline '{}'".format(pipeline.get("id")))
                 self.write_zk.set_as_json(pipeline_node, pipeline)

--- a/src/migrator/nlp_pipelines_migrator.py
+++ b/src/migrator/nlp_pipelines_migrator.py
@@ -73,7 +73,6 @@ def fix_pipeline_extractor_stages(pipeline):
     Use this class to upgrade from 2.1.x to 3.0.x
 """
 class PipelinesNLPMigrator3x:
-
     def __init__(self, config, zk, old_zk):
         self.class_loader = ClassLoader()
         self.zk_fusion_host = config["fusion.zk.connect"]

--- a/src/migrator/nlp_pipelines_migrator.py
+++ b/src/migrator/nlp_pipelines_migrator.py
@@ -88,10 +88,10 @@ class PipelinesNLPMigrator3x:
         # Get all the index pipelines
         zk_pipelines_node = "{}/{}".format(self.zk_fusion_node, INDEXPIPELINES_ZPATH)
 
-		if self.old_zk and self.old_zk.exists(zk_pipelines_node):
-			read_zk = old_zk
+        if self.old_zk and self.old_zk.exists(zk_pipelines_node):
+            read_zk = old_zk
         elif not self.read_zk.exists(zk_pipelines_node):
-        	logging.info("NLP znode path {} does not exist. No migrations to perform".format(zk_pipeline_node))
+            logging.info("NLP znode path {} does not exist. No migrations to perform".format(zk_pipeline_node))
             return
 
         children = self.read_zk.get_children(zk_pipelines_node)

--- a/src/migrator/proxy_pojo_migrator.py
+++ b/src/migrator/proxy_pojo_migrator.py
@@ -8,7 +8,7 @@ def update_initmeta_pojo(config, zk, old_zk):
     
     # if the POJO does not exist on either server, exit... Otherwise, grab it from the appropriate server
     if old_zk and old_zk.exists(initmeta_znode_path):
-        value, zstat = old_zk.get(initmeta_znode_pathh)    
+        value, zstat = old_zk.get(initmeta_znode_path)    
     elif zk.exists(initmeta_znode_path):
         value, zstat = zk.get(initmeta_znode_path)
     else:

--- a/src/migrator/proxy_pojo_migrator.py
+++ b/src/migrator/proxy_pojo_migrator.py
@@ -1,8 +1,9 @@
 import json
 import logging
 
+logger = logging.getLogger(__name__)
+
 def update_initmeta_pojo(config, zk, old_zk):
-    logger = logging.getLogger(__name__)
     initmeta_znode_path = "{}/sys/init-meta".format(config["proxy.namespace"])
     
     # if the POJO does not exist on either server, exit... Otherwise, grab it from the appropriate server

--- a/src/migrator/proxy_pojo_migrator.py
+++ b/src/migrator/proxy_pojo_migrator.py
@@ -2,6 +2,7 @@ import json
 import logging
 
 def update_initmeta_pojo(config, zk, old_zk):
+    logger = logging.getLogger(__name__)
     initmeta_znode_path = "{}/sys/init-meta".format(config["proxy.namespace"])
     
     # if the POJO does not exist on either server, exit... Otherwise, grab it from the appropriate server
@@ -12,8 +13,8 @@ def update_initmeta_pojo(config, zk, old_zk):
     else:
         # I am leaving this in here for now but unsure why the system used to just warn and continue instead
         # of exiting or returning when the init-meta POJO doesn't exist
-        logging.warn("init-meta POJO does not exist at zpath '{}'".format(initmeta_znode_path))
-        #logging.critical("init-meta POJO does not exist at zpath '{}'".format(initmeta_znode_path))
+        logger.warn("init-meta POJO does not exist at zpath '{}'".format(initmeta_znode_path))
+        #logger.critical("init-meta POJO does not exist at zpath '{}'".format(initmeta_znode_path))
         #sys.exit(1)
 
     # Read the payload from Zookeeper
@@ -21,6 +22,6 @@ def update_initmeta_pojo(config, zk, old_zk):
     deser_payload["datasets-installed-at"] = deser_payload.get("initialized-at")
     deser_payload["initial-db-installed-at"] = deser_payload.get("initialized-at")
 
-    logging.info("Updating init-meta payload at path '{}'".format(initmeta_znode_path))
+    logger.info("Updating init-meta payload at path '{}'".format(initmeta_znode_path))
     # Write the updated payload to Zookeeper
     zk.set(initmeta_znode_path, value=json.dumps(deser_payload))

--- a/src/migrator/proxy_pojo_migrator.py
+++ b/src/migrator/proxy_pojo_migrator.py
@@ -1,13 +1,21 @@
 import json
 import logging
 
-def update_initmeta_pojo(config, zk):
+def update_initmeta_pojo(config, zk, old_zk):
     initmeta_znode_path = "{}/sys/init-meta".format(config["proxy.namespace"])
-    if not zk.exists(initmeta_znode_path):
+    
+    # if the POJO does not exist on either server, exit... Otherwise, grab it from the appropriate server
+    if old_zk and old_zk.exists(initmeta_znode_path):
+        value, zstat = old_zk.get(initmeta_znode_pathh)    
+    elif zk.exists(initmeta_znode_path):
+        value, zstat = zk.get(initmeta_znode_path)
+    else:
+        # I am leaving this in here for now but unsure why the system used to just warn and continue instead
+        # of exiting or returning when the init-meta POJO doesn't exist
         logging.warn("init-meta POJO does not exist at zpath '{}'".format(initmeta_znode_path))
+        #sys.exit("init-meta POJO does not exist at zpath '{}'".format(initmeta_znode_path))
 
     # Read the payload from Zookeeper
-    value, zstat = zk.get(initmeta_znode_path)
     deser_payload = json.loads(value)
     deser_payload["datasets-installed-at"] = deser_payload.get("initialized-at")
     deser_payload["initial-db-installed-at"] = deser_payload.get("initialized-at")

--- a/src/migrator/proxy_pojo_migrator.py
+++ b/src/migrator/proxy_pojo_migrator.py
@@ -13,7 +13,8 @@ def update_initmeta_pojo(config, zk, old_zk):
         # I am leaving this in here for now but unsure why the system used to just warn and continue instead
         # of exiting or returning when the init-meta POJO doesn't exist
         logging.warn("init-meta POJO does not exist at zpath '{}'".format(initmeta_znode_path))
-        #sys.exit("init-meta POJO does not exist at zpath '{}'".format(initmeta_znode_path))
+        #logging.critical("init-meta POJO does not exist at zpath '{}'".format(initmeta_znode_path))
+        #sys.exit(1)
 
     # Read the payload from Zookeeper
     deser_payload = json.loads(value)

--- a/src/migrator/splitter_migrator.py
+++ b/src/migrator/splitter_migrator.py
@@ -210,7 +210,7 @@ class SplitterMigrator():
 
     # no need to verify that connectors znode exist because it is used to just define datasources_znode
     if self.old_zk and self.old_zk.exists(datasources_znode):
-      read_zk = old_zk
+      read_zk = self.old_zk
     elif not self.read_zk.exists(datasources_znode):
       logger.info("Connectors znode path {} does not exist. No migrations to perform".format(datasources_znode))
       return

--- a/src/migrator/splitter_migrator.py
+++ b/src/migrator/splitter_migrator.py
@@ -6,6 +6,7 @@ import logging
 
 
 class SplitterMigrator():
+  logger = logging.getLogger(__name__)
   DEFAULT_CSV_PARSER = {
     "type": "csv",
     "charset": "detect",
@@ -124,7 +125,7 @@ class SplitterMigrator():
     return archive_parser
 
   def migrate_anda_splitter(self, datasource):
-    logging.info("Executing migrate_anda_splitter for DS {}".format(datasource["id"]))
+    logger.info("Executing migrate_anda_splitter for DS {}".format(datasource["id"]))
     parsers = []
     splitter = dict(datasource[PROPERTIES].pop(SPLIT_CSV, {}))
     split_archives = bool(datasource[PROPERTIES].pop(SPLIT_ARCHIVES, False))
@@ -150,7 +151,7 @@ class SplitterMigrator():
     return parsers, datasource
 
   def migrate_fs_splitter(self, datasource):
-    logging.info("Executing migrate_fs_splitter for DS {}".format(datasource["id"]))
+    logger.info("Executing migrate_fs_splitter for DS {}".format(datasource["id"]))
     splitter = datasource[PROPERTIES].pop(SPLITTER, {})
 
     if len(splitter) == 0:
@@ -193,7 +194,7 @@ class SplitterMigrator():
 
     zk_node = "{}/parsers/{}".format(self.zk_fusion_node, parser_name)
 
-    logging.info("Creating parser '{}' at path {}".format(parser_name, zk_node))
+    logger.info("Creating parser '{}' at path {}".format(parser_name, zk_node))
     
     if not self.write_zk.exists(zk_node):
       self.write_zk.create(zk_node, makepath=True)
@@ -211,7 +212,7 @@ class SplitterMigrator():
     if self.old_zk and self.old_zk.exists(datasources_znode):
       read_zk = old_zk
     elif not self.read_zk.exists(datasources_znode):
-      logging.info("Connectors znode path {} does not exist. No migrations to perform".format(datasources_znode))
+      logger.info("Connectors znode path {} does not exist. No migrations to perform".format(datasources_znode))
       return
 
     children = self.read_zk.get_children(datasources_znode)

--- a/src/migrator/splitter_migrator.py
+++ b/src/migrator/splitter_migrator.py
@@ -4,9 +4,9 @@ from src.utils.constants import *
 import json
 import logging
 
+logger = logging.getLogger(__name__)
 
 class SplitterMigrator():
-  logger = logging.getLogger(__name__)
   DEFAULT_CSV_PARSER = {
     "type": "csv",
     "charset": "detect",

--- a/src/migrator/znodes_migration.py
+++ b/src/migrator/znodes_migration.py
@@ -1,8 +1,9 @@
 import sys
 import logging
 
-class ZNodesMigrator:
-    logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+
+class ZNodesMigrator:    
     def __init__(self, config, zk, old_zk):
         self.config = config
         self.zk = zk

--- a/src/migrator/znodes_migration.py
+++ b/src/migrator/znodes_migration.py
@@ -2,9 +2,10 @@ import sys
 import logging
 
 class ZNodesMigrator:
-    def __init__(self, config, zk):
+    def __init__(self, config, zk, old_zk):
         self.config = config
         self.zk = zk
+        self.old_zk = old_zk
 
     def start(self):
         self.migrate_solr_data()
@@ -20,29 +21,58 @@ class ZNodesMigrator:
     def migrate_core_data(self):
         logging.info("Migrating api data to new ZK namespace {}".format(self.config["api.namespace"]))
         old_core_znode_root = "/lucid"
-        if not self.zk.exists(old_core_znode_root):
+        
+        if self.old_zk.exists(old_core_znode_root):
+        	self.copy_znode_data(self.old_zk.get_children(old_core_znode_root), old_core_znode_root, self.config["api.namespace"])
+        else if self.zk.exists(old_core_znode_root):
+        	self.copy_znode_data(self.zk.get_children(old_core_znode_root), old_core_znode_root, self.config["api.namespace"])
+        else:
             sys.exit("Could not find zkpath '{}'".format(old_core_znode_root))
-        self.copy_znode_data(self.zk.get_children(old_core_znode_root), old_core_znode_root, self.config["api.namespace"])
 
     def migrate_proxy_data(self):
         logging.info("Migrating proxy data to new ZK namespace {}".format(self.config["proxy.namespace"]))
         old_core_znode_root = "/lucid-apollo-admin"
-        if not self.zk.exists(old_core_znode_root):
+        if self.old_zk.exists(old_core_znode_root):
+        	self.copy_znode_data(self.old_zk.get_children(old_core_znode_root), old_core_znode_root, self.config["proxy.namespace"])
+        else if self.zk.exists(old_core_znode_root):
+        	self.copy_znode_data(self.zk.get_children(old_core_znode_root), old_core_znode_root, self.config["proxy.namespace"])
+        else:
             sys.exit("Could not find zkpath '{}'".format(old_core_znode_root))
-        self.copy_znode_data(self.zk.get_children(old_core_znode_root), old_core_znode_root, self.config["proxy.namespace"])
 
     def copy_znode_data(self, znodes, old_root, new_root):
         for node_name in znodes:
             logging.debug("Migrating znode '{}' data from old path '{}' to new path '{}'".format(node_name, old_root, new_root))
-            znode_fullpath = "{}/{}".format(old_root, node_name)
-            if self.zk.exists(znode_fullpath):
+            
+            # Get proper root if old root is just "/"
+            if old_root == '/':
+            	znode_fullpath = "/{}".format(node_name)
+            else:
+	            znode_fullpath = "{}/{}".format(old_root, node_name)
+			
+			# if oldzk is present and the node exists there then grab the information from the old host
+			if self.old_zk && self.old_zk.exists(znode_fullpath):
+				value, zstat = self.old_zk.get(znode_fullpath)
+                children = self.old_zk.get_children(znode_fullpath)
+            # if oldzk doesn't exist or have the node information then check newzk for it 
+            elif self.zk.exists(znode_fullpath):  
                 value, zstat = self.zk.get(znode_fullpath)
-                new_fullpath = "{}/{}".format(new_root, node_name)
-                self.migrate_znode_data(new_fullpath, value)
                 children = self.zk.get_children(znode_fullpath)
-                self.copy_znode_data(children, znode_fullpath, "{}/{}".format(new_root, node_name))
+            # if neither have the node then log the error and skip to the next one
             else:
                 logging.error("Znode path '{}' does not exist".format(znode_fullpath))
+                return
+            
+            # generate the new_fullpath
+            if new_root:
+            	new_fullpath = "{}/{}".format(new_root, node_name)
+            else:
+            	new_fullpath = "/{}".format(node_name)
+
+            # actually save the data to the new zk or recurse to children
+            if value:
+                self.migrate_znode_data(new_fullpath, value)
+            if children:
+                self.copy_znode_data(children, znode_fullpath, new_fullpath)
 
     def migrate_znode_data(self, path, data):
         if not self.zk.exists(path):

--- a/src/migrator/znodes_migration3.py
+++ b/src/migrator/znodes_migration3.py
@@ -16,7 +16,8 @@ class ZNodesMigrator3:
         logging.info("Migrating Solr data from {} to new ZK namespace {}".format(self.old_config["solr.namespace"], self.config["solr.namespace"]))
         old_solr_znode_root = self.old_config["solr.namespace"]
         if not self.zk.exists(old_solr_znode_root):
-            sys.exit("Could not find zkpath '{}'".format(old_solr_znode_root))
+            logging.critical("Could not find zkpath '{}'".format(old_solr_znode_root))
+            sys.exit(1)
         solr_znodes = ["aliases.json", "clusterstate.json", "collections", "configs", "live_nodes", "overseer",
                        "overseer_elect", "security.json"]
         self.copy_znode_data(solr_znodes, self.old_config["solr.namespace"], self.config["solr.namespace"])
@@ -25,14 +26,16 @@ class ZNodesMigrator3:
         logging.info("Migrating api data from {} to new ZK namespace {}".format(self.old_config["api.namespace"], self.config["api.namespace"]))
         old_core_znode_root = self.old_config["api.namespace"]
         if not self.zk.exists(old_core_znode_root):
-            sys.exit("Could not find zkpath '{}'".format(old_core_znode_root))
+            logging.critical("Could not find zkpath '{}'".format(old_core_znode_root))
+            sys.exit(1)
         self.copy_znode_data(self.zk.get_children(old_core_znode_root), old_core_znode_root, self.config["api.namespace"])
 
     def migrate_proxy_data(self):
         logging.info("Migrating proxy data from {} to new ZK namespace {}".format(self.old_config["proxy.namespace"], self.config["proxy.namespace"]))
         old_core_znode_root = self.old_config["proxy.namespace"]
         if not self.zk.exists(old_core_znode_root):
-            sys.exit("Could not find zkpath '{}'".format(old_core_znode_root))
+            logging.critical("Could not find zkpath '{}'".format(old_core_znode_root))
+            sys.exit(1)
         self.copy_znode_data(self.zk.get_children(old_core_znode_root), old_core_znode_root, self.config["proxy.namespace"])
 
     def copy_znode_data(self, znodes, old_root, new_root):

--- a/src/migrator/znodes_migration3.py
+++ b/src/migrator/znodes_migration3.py
@@ -2,6 +2,7 @@ import sys
 import logging
 
 class ZNodesMigrator3:
+    logger = logging.getLogger(__name__)
     def __init__(self, old_config, config, zk):
         self.old_config = old_config
         self.config = config
@@ -13,34 +14,34 @@ class ZNodesMigrator3:
         self.migrate_proxy_data()
 
     def migrate_solr_data(self):
-        logging.info("Migrating Solr data from {} to new ZK namespace {}".format(self.old_config["solr.namespace"], self.config["solr.namespace"]))
+        logger.info("Migrating Solr data from {} to new ZK namespace {}".format(self.old_config["solr.namespace"], self.config["solr.namespace"]))
         old_solr_znode_root = self.old_config["solr.namespace"]
         if not self.zk.exists(old_solr_znode_root):
-            logging.critical("Could not find zkpath '{}'".format(old_solr_znode_root))
+            logger.critical("Could not find zkpath '{}'".format(old_solr_znode_root))
             sys.exit(1)
         solr_znodes = ["aliases.json", "clusterstate.json", "collections", "configs", "live_nodes", "overseer",
                        "overseer_elect", "security.json"]
         self.copy_znode_data(solr_znodes, self.old_config["solr.namespace"], self.config["solr.namespace"])
 
     def migrate_core_data(self):
-        logging.info("Migrating api data from {} to new ZK namespace {}".format(self.old_config["api.namespace"], self.config["api.namespace"]))
+        logger.info("Migrating api data from {} to new ZK namespace {}".format(self.old_config["api.namespace"], self.config["api.namespace"]))
         old_core_znode_root = self.old_config["api.namespace"]
         if not self.zk.exists(old_core_znode_root):
-            logging.critical("Could not find zkpath '{}'".format(old_core_znode_root))
+            logger.critical("Could not find zkpath '{}'".format(old_core_znode_root))
             sys.exit(1)
         self.copy_znode_data(self.zk.get_children(old_core_znode_root), old_core_znode_root, self.config["api.namespace"])
 
     def migrate_proxy_data(self):
-        logging.info("Migrating proxy data from {} to new ZK namespace {}".format(self.old_config["proxy.namespace"], self.config["proxy.namespace"]))
+        logger.info("Migrating proxy data from {} to new ZK namespace {}".format(self.old_config["proxy.namespace"], self.config["proxy.namespace"]))
         old_core_znode_root = self.old_config["proxy.namespace"]
         if not self.zk.exists(old_core_znode_root):
-            logging.critical("Could not find zkpath '{}'".format(old_core_znode_root))
+            logger.critical("Could not find zkpath '{}'".format(old_core_znode_root))
             sys.exit(1)
         self.copy_znode_data(self.zk.get_children(old_core_znode_root), old_core_znode_root, self.config["proxy.namespace"])
 
     def copy_znode_data(self, znodes, old_root, new_root):
         for node_name in znodes:
-            logging.debug("Migrating znode '{}' data from old path '{}' to new path '{}'".format(node_name, old_root, new_root))
+            logger.debug("Migrating znode '{}' data from old path '{}' to new path '{}'".format(node_name, old_root, new_root))
             znode_fullpath = "{}/{}".format(old_root, node_name)
             if self.zk.exists(znode_fullpath):
                 value, zstat = self.zk.get(znode_fullpath)
@@ -49,9 +50,9 @@ class ZNodesMigrator3:
                 children = self.zk.get_children(znode_fullpath)
                 self.copy_znode_data(children, znode_fullpath, "{}/{}".format(new_root, node_name))
             else:
-                logging.error("Znode path '{}' does not exist".format(znode_fullpath))
+                logger.error("Znode path '{}' does not exist".format(znode_fullpath))
 
     def migrate_znode_data(self, path, data):
         if not self.zk.exists(path):
-            logging.debug("not copying znode '{}' since it already exists".format(path))
+            logger.debug("not copying znode '{}' since it already exists".format(path))
             real_path = self.zk.create(path, value=data, makepath=True)

--- a/src/migrator/znodes_migration3.py
+++ b/src/migrator/znodes_migration3.py
@@ -1,8 +1,9 @@
 import sys
 import logging
 
-class ZNodesMigrator3:
-    logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+
+class ZNodesMigrator3:    
     def __init__(self, old_config, config, zk):
         self.old_config = old_config
         self.config = config

--- a/src/upgrade-3.0.x.py
+++ b/src/upgrade-3.0.x.py
@@ -20,18 +20,18 @@ from src.migrator.api_pojo_migrator import update_searchcluster_pojo
 
 logging.basicConfig(level=logging.INFO,
                     format="%(asctime)s - %(name)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
-
+logger = logging.getLogger(__name__)
 parser = argparse.ArgumentParser(description="Migrate data")
 parser.add_argument("--fusion-url", default="http://localhost:8764/api", help="URL of the Fusion proxy server")
 parser.add_argument("--fusion-username", default="admin", help="Username to use when authenticating to the Fusion application (should be an admin)")
 
 def ensure_env_variables_defined():
     if not VariablesHelper.ensure_fusion_home():
-        logging.info("FUSION_HOME env variable is not set")
+        logger.info("FUSION_HOME env variable is not set")
         exit()
 
     if not VariablesHelper.ensure_old_fusion_home():
-        logging.info("FUSION_OLD_HOME env variable is not set")
+        logger.info("FUSION_OLD_HOME env variable is not set")
         exit()
 
 def start_zk_client(fconfig):
@@ -51,12 +51,12 @@ def upgrade_zk_data(fusion_old_home, fusion_home, old_fusion_version, fusion_ver
 
     zk_client = start_zk_client(config)
 
-    logging.info("Migrating from fusion version '{}' to '{}'".format(old_fusion_version, fusion_version))
+    logger.info("Migrating from fusion version '{}' to '{}'".format(old_fusion_version, fusion_version))
     if StrictVersion(fusion_version) > StrictVersion(old_fusion_version) >= StrictVersion("3.0.0"):
         znode_migrator = ZNodesMigrator3(old_config, config, zk_client)
-        logging.info("Copying znodes from old fusion paths to new paths")
+        logger.info("Copying znodes from old fusion paths to new paths")
         znode_migrator.start()
-        logging.info("Migration from old znode paths to new paths complete")
+        logger.info("Migration from old znode paths to new paths complete")
 
         update_searchcluster_pojo(config, zk_client)
 

--- a/src/upgrade-ds-1.2-to-2.4.py
+++ b/src/upgrade-ds-1.2-to-2.4.py
@@ -14,7 +14,7 @@ from src.migrator.nlp_pipelines_migrator import PipelinesNLPMigrator
 from src.utils.variables_helper import VariablesHelper
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
-
+logger = logging.getLogger(__name__)
 parser = argparse.ArgumentParser(description="Migrate datasource properties")
 parser.add_argument("--datasources", required=True, nargs='+',
                     help="Set 'all' to migrate all datasources with a valid migrator implementation, or set a datasources list to be migrated")
@@ -24,11 +24,11 @@ if __name__ == "__main__":
   data_sources_to_migrate = args.datasources
 
   if not VariablesHelper.ensure_fusion_home():
-    logging.info("FUSION_HOME variable is not set")
+    logger.info("FUSION_HOME variable is not set")
     exit()
 
   if not VariablesHelper.ensure_old_fusion_home():
-    logging.info("FUSION_OLD_HOME variable is not set")
+    logger.info("FUSION_OLD_HOME variable is not set")
     exit()
 
   connectors_migrator = ConnectorsMigrator()

--- a/src/upgrade-ds-2.1-to-2.4.py
+++ b/src/upgrade-ds-2.1-to-2.4.py
@@ -14,7 +14,7 @@ from src.migrator.nlp_pipelines_migrator import PipelinesNLPMigrator
 from src.utils.variables_helper import VariablesHelper
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
-
+logger = logging.getLogger(__name__)
 parser = argparse.ArgumentParser(description="Migrate datasource properties")
 parser.add_argument("--datasources", required=True, nargs='+',
                     help="Set 'all' to migrate all datasources with a valid migrator implementation, or set a datasources list to be migrated")
@@ -24,11 +24,11 @@ if __name__ == "__main__":
   data_sources_to_migrate = args.datasources
 
   if not VariablesHelper.ensure_fusion_home():
-    logging.info("FUSION_HOME variable was not set")
+    logger.info("FUSION_HOME variable was not set")
     exit()
 
   if not VariablesHelper.ensure_old_fusion_home():
-    logging.info("FUSION_OLD_HOME variable is not set")
+    logger.info("FUSION_OLD_HOME variable is not set")
     exit()
 
   connectors_migrator = ConnectorsMigrator()

--- a/src/upgrade-to-3.0.py
+++ b/src/upgrade-to-3.0.py
@@ -91,7 +91,7 @@ def upgrade_zk_data(fusion_home, old_fusion_version, fusion_version, fusion_old_
         old_config = load_or_generate_config(fusion_old_home, 'ui', fusion_home)
         old_zk_client = start_zk_client(old_config)
     elif fusion_old_zk:
-        old_zk_client = start_zk_client(fusion_old_zk)
+        old_zk_client = start_zk_client({'fusion.zk.connect': fusion_old_zk})
 
     logger.info("Migrating from fusion version '{}' to '{}'".format(old_fusion_version, fusion_version))
     if StrictVersion(fusion_version) >= StrictVersion("3.0.0") > StrictVersion(old_fusion_version):

--- a/src/upgrade-to-3.0.py
+++ b/src/upgrade-to-3.0.py
@@ -27,7 +27,7 @@ from src.migrator.splitter_migrator import SplitterMigrator
 
 log_format = "%(asctime)s - %(name)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
 log_level = logging.INFO
-logging.basicConfig(log_level, format=log_format)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
 
 logger = logging.getLogger(__name__)
 

--- a/src/upgrade-to-3.0.py
+++ b/src/upgrade-to-3.0.py
@@ -25,9 +25,8 @@ from src.utils.zookeeper_client import ZookeeperClient
 from src.migrator.config_migrator import ConfigMigrator
 from src.migrator.splitter_migrator import SplitterMigrator
 
-
-logging.basicConfig(level=logging.INFO,
-                    format="%(asctime)s - %(name)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+log_format = "%(asctime)s - %(name)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+log_level = logging.INFO
 
 parser = argparse.ArgumentParser(description="Migrate datasource properties")
 parser.add_argument("--datasources", 
@@ -166,19 +165,22 @@ def upgrade_banana_dashboards(url, username, password):
 
 if __name__ == "__main__":
     args = parser.parse_args()
-    log_level = args.log_level.lower()
-    if log_level == 'critical':
-        logging.setLevel(logging.CRITICAL)
-    elif log_level == 'error':
-        logging.setLevel(logging.ERROR)
-    elif log_level == 'warning':
-        logging.setLevel(logging.WARNING)
-    elif log_level == 'info':
-        logging.setLevel(logging.INFO)
-    elif log_level == 'debug':
-        logging.setLevel(logging.DEBUG)
-    else
-        logging.setLevel(logging.INFO)
+    loger_level = args.log_level.lower()
+    if loger_level == 'critical':
+        log_level = logging.CRITICAL
+    elif loger_level == 'error':
+        log_level = logging.ERROR
+    elif loger_level == 'warning':
+        log_level = logging.WARNING
+    elif loger_level == 'info':
+        log_level = logging.INFO
+    elif loger_level == 'debug':
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
+    
+    logging.basicConfig(log_level,
+                        format=log_format)
     
     data_sources_to_migrate = args.datasources
     type_of_upgrade = args.upgrade

--- a/src/upgrade-to-3.0.py
+++ b/src/upgrade-to-3.0.py
@@ -84,7 +84,8 @@ def upgrade_zk_data(fusion_home, fusion_old_home, old_fusion_version, fusion_ver
     old_config = None
     old_zk_client = None
     if fusion_old_home:
-        old_config = load_or_generate_config(fusion_old_home)
+    	#TODO: Check version for < 3 before assuming that need to pass in new fusion_home for jar
+        old_config = load_or_generate_config(fusion_old_home, 'ui', fusion_home)
         old_zk_client = start_zk_client(old_config)
 
     logger.info("Migrating from fusion version '{}' to '{}'".format(old_fusion_version, fusion_version))

--- a/src/upgrade-to-3.0.py
+++ b/src/upgrade-to-3.0.py
@@ -27,7 +27,6 @@ from src.migrator.splitter_migrator import SplitterMigrator
 
 log_format = "%(asctime)s - %(name)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
 log_level = logging.INFO
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
 
 logger = logging.getLogger(__name__)
 
@@ -181,6 +180,8 @@ if __name__ == "__main__":
         log_level = logging.DEBUG
     else:
         log_level = logging.INFO
+    
+    logging.basicConfig(level=log_level, format=log_format)
     logger.setLevel(log_level)
     
     data_sources_to_migrate = args.datasources

--- a/src/utils/class_loader.py
+++ b/src/utils/class_loader.py
@@ -3,11 +3,12 @@
 import logging
 
 class ClassLoader:
+  logger = logging.getLogger(__name__)
   classes_cache = {}
 
   def get_class(self, classname):
 
-    logging.debug("Loading class: {}".format(classname))
+    logger.debug("Loading class: {}".format(classname))
 
     if self.classes_cache.has_key(classname):
       return self.classes_cache.get(classname)
@@ -20,7 +21,7 @@ class ClassLoader:
       try:
         module = getattr(module, component)
       except:
-        logging.error("Component not found: %s", component)
+        logger.error("Component not found: %s", component)
         return None
 
     self.classes_cache[classname] = module

--- a/src/utils/class_loader.py
+++ b/src/utils/class_loader.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 import logging
+logger = logging.getLogger(__name__)
 
 class ClassLoader:
-  logger = logging.getLogger(__name__)
   classes_cache = {}
 
   def get_class(self, classname):

--- a/src/utils/load_fusion_3x_config.py
+++ b/src/utils/load_fusion_3x_config.py
@@ -33,7 +33,7 @@ def generate_config_file(fusion_home, service="ui"):
     # even if the file exists, it could have been generated off a seperate set of fusion configs or even a different 
     # fusion version so we should ALWAYS recreate it
     if os.path.exists(file_fullpath):
-        logging.info("File '{}' exists, deleting old version"))
+        logging.info("File '{}' exists, deleting old version".format(file_fullpath))
         os.remove(file_fullpath)
     logging.info("Creating config file using agent")
     jar_path = os.path.join(fusion_home, "apps", "lucidworks-agent.jar")
@@ -43,16 +43,19 @@ def generate_config_file(fusion_home, service="ui"):
     popen = subprocess.Popen(args)
     return_code = popen.wait()
     if not os.path.exists(file_fullpath):
-        sys.exit("Failed to generate config file using the command '{}' at path '{}'. Return code '{}'".format(command, file_fullpath, return_code))
+        logging.critical("Failed to generate config file using the command '{}' at path '{}'. Return code '{}'".format(command, file_fullpath, return_code))
+        sys.exit(1)
     logging.info("Generated config file at path '{}'".format(file_fullpath))
     return file_fullpath
 
 
 def load_config_from_file(path, service="ui"):
     if not os.path.exists(path):
-        sys.exit(
-            "Config file does not exist at path '{0}'.\n Please run"
-            " 'java -jar apps/lucidworks-agent.jar config -o {1}.config.json {1}' command from '{2}' to generate the config file".format(path, service, VariablesHelper.FUSION_HOME))
+        logging.critical("CRITICAL: Config file does not exist at path '{0}'.\n Please run"
+                         " 'java -jar apps/lucidworks-agent.jar config -o {1}.config.json {1}' command from '{2}' "
+                         "to generate the config file".format(path, service, VariablesHelper.FUSION_HOME))
+        sys.exit(1)
+
     deser_payload = json.load(open(path))
     config = {}
     try:
@@ -84,7 +87,7 @@ def load_or_generate_config(fusion_home, service="ui"):
     # external zk and internal solr resulting in only a fusion.zk.connect string so you have to account for them both
     # Sidenote: I honestly have no idea why the config is being generated with a solr.zk.connect string when it isn't
     # defined in the fusion.properties... something in that Jar being run to generate the config is off
-    config["solr.namespace"] = parse_solr_namespace(config["solr.zk.connect"] || config["fusion.zk.connect"])
+    config["solr.namespace"] = parse_solr_namespace(config["solr.zk.connect"] or config["fusion.zk.connect"])
     return config
 
 

--- a/src/utils/load_fusion_3x_config.py
+++ b/src/utils/load_fusion_3x_config.py
@@ -88,6 +88,7 @@ def parse_solr_namespace(solr_zk_connect):
 def load_or_generate_config(fusion_home, service="ui", jar_home=None):
     config_file_path = generate_config_file(fusion_home, service, jar_home)
     config = load_config_from_file(config_file_path, service)
+    logger.debug('Configuration: {0}'.format(config))
     os.remove(config_file_path)
     # you're assuming here that if zk is external then solr is also external which may not be correct. You can have
     # external zk and internal solr resulting in only a fusion.zk.connect string so you have to account for them both
@@ -100,6 +101,7 @@ def load_or_generate_config(fusion_home, service="ui", jar_home=None):
 def load_or_generate_config3(fusion_home, service="ui", jar_home=None):
     config_file_path = generate_config_file(fusion_home, service, jar_home)
     config = load_config_from_file(config_file_path, service)
+    logger.debug('Configuration: {0}'.format(config))
     os.remove(config_file_path)
     # you're assuming here that if zk is external then solr is also external which may not be correct. You can have
     # external zk and internal solr resulting in only a fusion.zk.connect string so you have to account for them both

--- a/src/utils/resource_manager.py
+++ b/src/utils/resource_manager.py
@@ -5,8 +5,8 @@ import json
 import re
 import logging
 
-class ResourceManager:
-  logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+class ResourceManager:  
   def __init__(self):
     pass
 

--- a/src/utils/resource_manager.py
+++ b/src/utils/resource_manager.py
@@ -6,6 +6,7 @@ import re
 import logging
 
 class ResourceManager:
+  logger = logging.getLogger(__name__)
   def __init__(self):
     pass
 
@@ -14,6 +15,6 @@ class ResourceManager:
     source_dir = os.path.dirname(os.path.abspath(__file__))
     path = os.path.join(source_dir, "../resources/{}".
                         format(filename))
-    logging.info("Loading file from path {}".format(path))
+    logger.info("Loading file from path {}".format(path))
     with open(path) as data_file:
       return json.load(data_file)

--- a/src/utils/variables_helper.py
+++ b/src/utils/variables_helper.py
@@ -5,6 +5,7 @@ import sys
 import platform
 
 class VariablesHelper:
+  logger = logging.getLogger(__name__)
 
   def __init__(self):
     pass
@@ -83,7 +84,7 @@ class VariablesHelper:
     if m is not None:
       return m.group(0)
     else:
-      logging.error("Could not extract a valid version number from '{}'".format(version))
+      logger.critical("Could not extract a valid version number from '{}'".format(version))
       sys.exit(1)
      
   @staticmethod

--- a/src/utils/variables_helper.py
+++ b/src/utils/variables_helper.py
@@ -4,9 +4,8 @@ import logging
 import sys
 import platform
 
+logger = logging.getLogger(__name__)
 class VariablesHelper:
-  logger = logging.getLogger(__name__)
-
   def __init__(self):
     pass
 

--- a/src/utils/zookeeper_client.py
+++ b/src/utils/zookeeper_client.py
@@ -4,9 +4,9 @@ from kazoo.client import KazooClient
 import json
 import logging
 
+logger = logging.getLogger(__name__)
+
 class ZookeeperClient:
-  logger = logging.getLogger(__name__)
-  
   def __init__(self, zk_host):
     self.zk = KazooClient(hosts=zk_host)
 

--- a/src/utils/zookeeper_client.py
+++ b/src/utils/zookeeper_client.py
@@ -5,27 +5,29 @@ import json
 import logging
 
 class ZookeeperClient:
+  logger = logging.getLogger(__name__)
+  
   def __init__(self, zk_host):
     self.zk = KazooClient(hosts=zk_host)
 
   def start(self):
-    logging.info("Starting zookeeper client")
+    logger.info("Starting zookeeper client")
     self.zk.start()
 
   def exists(self, node_path):
-    logging.info("Verifying zk node: %s", node_path)
+    logger.info("Verifying zk node: %s", node_path)
     return self.zk.exists(node_path)
 
   def get_children(self, node_path):
-    logging.info("Getting children for node: {}".format(node_path))
+    logger.info("Getting children for node: {}".format(node_path))
 
     return self.zk.get_children(node_path)
 
   def get_as_json(self, node_path):
-    logging.info("Getting zk node: %s", node_path)
+    logger.info("Getting zk node: %s", node_path)
     (data, stats) = self.zk.get(node_path)
     return json.loads(data)
 
   def set_as_json(self, node_path, object):
-    logging.info("Setting value to zk node: %s", node_path)
+    logger.info("Setting value to zk node: %s", node_path)
     self.zk.set(node_path, json.dumps(object, indent=2))


### PR DESCRIPTION
- Allow for migration using old ZK either with config file from $FUSION_OLD_HOME or from a passed ZK connect string
	+ Fixes system not being able to read old data from same zk if not doing just a namespace update
- Changed static Logging module to logger instances for cleaner run and better consistency with python practices
- Added log-level flag to params to allow user to pass in a log level
- Fixed "exit()" comments so that comments were ouput as CRITICAL level logs and exit's with 1 status
- Fixed issue where just a base path in zk of / was using // instead
- Fixed issue where old ui.config.json file was not being deleted even though it should always be rewritten in case you are running the script against another Fusion version or after you have changed the properties
- There is a TODO on line 90 of src/upgrade-to-3.0.py where we are passing in the JAR location every time when trying to load an old config, that may not be necessary if the version is >= 3.0.0 but I wasn't sure how the versioning utils work so thought you could have a look at making that conditional